### PR TITLE
Update sysinternals-suite.md

### DIFF
--- a/sysinternals/downloads/sysinternals-suite.md
+++ b/sysinternals/downloads/sysinternals-suite.md
@@ -20,7 +20,7 @@ Updated: December 12, 2017
 The Sysinternals Troubleshooting Utilities have been rolled up into a
 single Suite of tools. This file contains the individual troubleshooting
 tools and help files. It does not contain non-troubleshooting tools like
-the BSOD Screen Saver or NotMyFault.
+the BSOD Screen Saver.
 
 The Suite is a bundling of the following selected Sysinternals
 Utilities:

--- a/sysinternals/downloads/sysinternals-suite.md
+++ b/sysinternals/downloads/sysinternals-suite.md
@@ -24,21 +24,21 @@ the BSOD Screen Saver.
 
 The Suite is a bundling of the following selected Sysinternals
 Utilities:
-[AccessChk](accesschk.md)  | [AccessEnum](accessenum.md)  | [AdExplorer](adexplorer.md)  | [AdInsight](adinsight.md)  | [AdRestore](adrestore.md)  | 
-[Autologon](autologon.md)  | [Autoruns](autoruns.md)  | [BgInfo](bginfo.md)  | [BlueScreen](bluescreen.md)  | [CacheSet](cacheset.md)  | 
-[ClockRes](clockres.md)  | [Contig](contig.md)  | [Coreinfo](coreinfo.md)  | [Ctrl2Cap](ctrl2cap.md)  | [DebugView](debugview.md)  | 
-[Desktops](desktops.md)  | [Disk2vhd](disk2vhd.md)  | [DiskExt](diskext.md)  | [DiskMon](diskmon.md)  | [DiskView](diskview.md)  | 
-[Disk Usage (DU)](du.md)  | [EFSDump](efsdump.md)  | [FindLinks](findlinks.md)  | [Handle](handle.md)  | [Hex2dec](hex2dec.md)  | 
-[Junction](junction.md)  | [LDMDump](ldmdump.md)  | [ListDLLs](listdlls.md)  | [LiveKd](livekd.md)  | [LoadOrder](loadorder.md)  | 
-[LogonSessions](logonsessions.md)  | [MoveFile](movefile.md)  | [NotMyFault](notmyfault.md)  | [NTFSInfo](ntfsinfo.md)  | [PageDefrag](pagedefrag.md)  | 
-[PendMoves](pendmoves.md)  | [PipeList](pipelist.md)  | [PortMon](portmon.md)  | [ProcDump](procdump.md)  | [Process Explorer](process-explorer.md)  | 
-[Process Monitor](procmon.md)  | [PsExec](psexec.md)  | [PsFile](psfile.md)  | [PsGetSid](psgetsid.md)  | [PsInfo](psinfo.md)  | 
-[PsKill](pskill.md)  | [PsList](pslist.md)  | [PsLoggedOn](psloggedon.md)  | [PsLogList](psloglist.md)  | [PsPasswd](pspasswd.md)  | 
-[PsPing](psping.md)  | [PsService](psservice.md)  | [PsShutdown](psshutdown.md)  | [PsSuspend](pssuspend.md)  | [PsTools](pstools.md)  | 
-[RAMMap](rammap.md)  | [RegDelNull](regdelnull.md)  | [RegHide](reghide.md)  | [RegJump](regjump.md)  | [Registry Usage (RU)](ru.md)  | 
-[SDelete](sdelete.md)  | [ShareEnum](shareenum.md)  | [ShellRunas](shellrunas.md)  | [Sigcheck](sigcheck.md)  | [Streams](streams.md)  | 
-[Strings](strings.md)  | [Sync](sync.md)  | [Sysmon](sysmon.md)  | [TCPView](tcpview.md)  | [VMMap](vmmap.md)  | 
-[VolumeID](volumeid.md)  | [WhoIs](whois.md)  | [WinObj](winobj.md)  | [ZoomIt](zoomit.md)
+[AccessChk](accesschk.md), [AccessEnum](accessenum.md), [AdExplorer](adexplorer.md), [AdInsight](adinsight.md), [AdRestore](adrestore.md), 
+[Autologon](autologon.md), [Autoruns](autoruns.md), [BgInfo](bginfo.md), [BlueScreen](bluescreen.md), [CacheSet](cacheset.md), 
+[ClockRes](clockres.md), [Contig](contig.md), [Coreinfo](coreinfo.md), [Ctrl2Cap](ctrl2cap.md), [DebugView](debugview.md), 
+[Desktops](desktops.md), [Disk2vhd](disk2vhd.md), [DiskExt](diskext.md), [DiskMon](diskmon.md), [DiskView](diskview.md), 
+[Disk Usage (DU)](du.md), [EFSDump](efsdump.md), [FindLinks](findlinks.md), [Handle](handle.md), [Hex2dec](hex2dec.md), 
+[Junction](junction.md), [LDMDump](ldmdump.md), [ListDLLs](listdlls.md), [LiveKd](livekd.md), [LoadOrder](loadorder.md), 
+[LogonSessions](logonsessions.md), [MoveFile](movefile.md), [NotMyFault](notmyfault.md), [NTFSInfo](ntfsinfo.md), [PageDefrag](pagedefrag.md), 
+[PendMoves](pendmoves.md), [PipeList](pipelist.md), [PortMon](portmon.md), [ProcDump](procdump.md), [Process Explorer](process-explorer.md), 
+[Process Monitor](procmon.md), [PsExec](psexec.md), [PsFile](psfile.md), [PsGetSid](psgetsid.md), [PsInfo](psinfo.md), 
+[PsKill](pskill.md), [PsList](pslist.md), [PsLoggedOn](psloggedon.md), [PsLogList](psloglist.md), [PsPasswd](pspasswd.md), 
+[PsPing](psping.md), [PsService](psservice.md), [PsShutdown](psshutdown.md), [PsSuspend](pssuspend.md), [PsTools](pstools.md), 
+[RAMMap](rammap.md), [RegDelNull](regdelnull.md), [RegHide](reghide.md), [RegJump](regjump.md), [Registry Usage (RU)](ru.md), 
+[SDelete](sdelete.md), [ShareEnum](shareenum.md), [ShellRunas](shellrunas.md), [Sigcheck](sigcheck.md), [Streams](streams.md), 
+[Strings](strings.md), [Sync](sync.md), [Sysmon](sysmon.md), [TCPView](tcpview.md), [VMMap](vmmap.md), 
+[VolumeID](volumeid.md), [WhoIs](whois.md), [WinObj](winobj.md), [ZoomIt](zoomit.md)
 
 
 [**Download Sysinternals Suite**](https://download.sysinternals.com/files/SysinternalsSuite.zip) (22.6 MB)  

--- a/sysinternals/downloads/sysinternals-suite.md
+++ b/sysinternals/downloads/sysinternals-suite.md
@@ -24,22 +24,21 @@ the BSOD Screen Saver.
 
 The Suite is a bundling of the following selected Sysinternals
 Utilities:
-[AccessChk](accesschk.md)  | [AccessEnum](accessenum.md)  | [AdExplorer](adexplorer.md)  | [AdInsight](adinsight.md)  | [AdRestore](adrestore.md)  |
-| [Autologon](autologon.md)  | [Autoruns](autoruns.md)  | [BgInfo](bginfo.md)  | [BlueScreen](bluescreen.md)  | [CacheSet](cacheset.md)  |
-| [ClockRes](clockres.md)  | [Contig](contig.md)  | [Coreinfo](coreinfo.md)  | [Ctrl2Cap](ctrl2cap.md)  | [DebugView](debugview.md)  |
-| [Desktops](desktops.md)  | [Disk2vhd](disk2vhd.md)  | [DiskExt](diskext.md)  | [DiskMon](diskmon.md)  | [DiskView](diskview.md)  |
-| [Disk Usage (DU)](du.md)  | [EFSDump](efsdump.md)  | [FileMon](filemon.md)  | [FindLinks](findlinks.md)  | [Handle](handle.md)  |
-| [Hex2dec](hex2dec.md)  | [Junction](junction.md)  | [LDMDump](ldmdump.md)  | [ListDLLs](listdlls.md)  | [LiveKd](livekd.md)  |
-| [LoadOrder](loadorder.md)  | [LogonSessions](logonsessions.md)  | [MoveFile](movefile.md)  | [NewSid](newsid.md)  | [NotMyFault](notmyfault.md)  |
-| [NTFSInfo](ntfsinfo.md)  | [PageDefrag](pagedefrag.md)  | [PendMoves](pendmoves.md)  | [PipeList](pipelist.md)  | [PortMon](portmon.md)  |
-| [ProcDump](procdump.md)  | [Process Explorer](process-explorer.md)  | [ProcFeatures](procfeatures.md)  | [Process Monitor](procmon.md)  | [PsExec](psexec.md)  |
-| [PsFile](psfile.md)  | [PsGetSid](psgetsid.md)  | [PsInfo](psinfo.md)  | [PsKill](pskill.md)  | [PsList](pslist.md)  |
-| [PsLoggedOn](psloggedon.md)  | [PsLogList](psloglist.md)  | [PsPasswd](pspasswd.md)  | [PsPing](psping.md)  | [PsService](psservice.md)  |
-| [PsShutdown](psshutdown.md)  | [PsSuspend](pssuspend.md)  | [PsTools](pstools.md)  | [RAMMap](rammap.md)  | [RegDelNull](regdelnull.md)  |
-| [RegHide](reghide.md)  | [RegJump](regjump.md)  | [RegMon](regmon.md)  | [Rootkit Revealer](rootkit-revealer.md)  | [Registry Usage (RU)](ru.md)  |
-| [SDelete](sdelete.md)  | [ShareEnum](shareenum.md)  | [ShellRunas](shellrunas.md)  | [Sigcheck](sigcheck.md)  | [Streams](streams.md)  |
-| [Strings](strings.md)  | [Sync](sync.md)  | [Sysmon](sysmon.md)  | [TCPView](tcpview.md)  | [VMMap](vmmap.md)  |
-| [VolumeID](volumeid.md)  | [WhoIs](whois.md)  | [WinObj](winobj.md)  | [ZoomIt](zoomit.md) | 
+[AccessChk](accesschk.md)  | [AccessEnum](accessenum.md)  | [AdExplorer](adexplorer.md)  | [AdInsight](adinsight.md)  | [AdRestore](adrestore.md)  | 
+[Autologon](autologon.md)  | [Autoruns](autoruns.md)  | [BgInfo](bginfo.md)  | [BlueScreen](bluescreen.md)  | [CacheSet](cacheset.md)  | 
+[ClockRes](clockres.md)  | [Contig](contig.md)  | [Coreinfo](coreinfo.md)  | [Ctrl2Cap](ctrl2cap.md)  | [DebugView](debugview.md)  | 
+[Desktops](desktops.md)  | [Disk2vhd](disk2vhd.md)  | [DiskExt](diskext.md)  | [DiskMon](diskmon.md)  | [DiskView](diskview.md)  | 
+[Disk Usage (DU)](du.md)  | [EFSDump](efsdump.md)  | [FindLinks](findlinks.md)  | [Handle](handle.md)  | [Hex2dec](hex2dec.md)  | 
+[Junction](junction.md)  | [LDMDump](ldmdump.md)  | [ListDLLs](listdlls.md)  | [LiveKd](livekd.md)  | [LoadOrder](loadorder.md)  | 
+[LogonSessions](logonsessions.md)  | [MoveFile](movefile.md)  | [NotMyFault](notmyfault.md)  | [NTFSInfo](ntfsinfo.md)  | [PageDefrag](pagedefrag.md)  | 
+[PendMoves](pendmoves.md)  | [PipeList](pipelist.md)  | [PortMon](portmon.md)  | [ProcDump](procdump.md)  | [Process Explorer](process-explorer.md)  | 
+[Process Monitor](procmon.md)  | [PsExec](psexec.md)  | [PsFile](psfile.md)  | [PsGetSid](psgetsid.md)  | [PsInfo](psinfo.md)  | 
+[PsKill](pskill.md)  | [PsList](pslist.md)  | [PsLoggedOn](psloggedon.md)  | [PsLogList](psloglist.md)  | [PsPasswd](pspasswd.md)  | 
+[PsPing](psping.md)  | [PsService](psservice.md)  | [PsShutdown](psshutdown.md)  | [PsSuspend](pssuspend.md)  | [PsTools](pstools.md)  | 
+[RAMMap](rammap.md)  | [RegDelNull](regdelnull.md)  | [RegHide](reghide.md)  | [RegJump](regjump.md)  | [Registry Usage (RU)](ru.md)  | 
+[SDelete](sdelete.md)  | [ShareEnum](shareenum.md)  | [ShellRunas](shellrunas.md)  | [Sigcheck](sigcheck.md)  | [Streams](streams.md)  | 
+[Strings](strings.md)  | [Sync](sync.md)  | [Sysmon](sysmon.md)  | [TCPView](tcpview.md)  | [VMMap](vmmap.md)  | 
+[VolumeID](volumeid.md)  | [WhoIs](whois.md)  | [WinObj](winobj.md)  | [ZoomIt](zoomit.md)
 
 
 [**Download Sysinternals Suite**](https://download.sysinternals.com/files/SysinternalsSuite.zip) (22.6 MB)  


### PR DESCRIPTION
* Remove *NotMyFault* from the third sentence of the introduction which incorrectly states that it is not included in the suite when it clearly is.
* Remove *RegMon*, *FileMon*, *NewSID*, *ProcFeatures*, and *RootkitRevealer* from the utilities list as they have all been removed from the suite some time ago.
* Remove duplicate pipes and replace pipes with commas  
I assume based on the previous formatting and history that this was supposed to be a table at one point but it doesn't render on GitHub or msdocs and I think commas read better in an inline list. Unfortunately GitHub Flavoured Markdown doesn't appear to support tables without a header anyway, but nevertheless I have kept the list to five items per row after removing entries and made the change to commas in a seperate commit in case pipes or table formatting is preferred.