### PR TITLE
Remove redundant links

### DIFF
--- a/sysinternals/downloads/sysinternals-suite.md
+++ b/sysinternals/downloads/sysinternals-suite.md
@@ -12,7 +12,7 @@ Sysinternals Suite
   
 
 **By Mark Russinovich**  
-Updated: December 18, 2018  
+Updated: December 22, 2018  
 [**Download Sysinternals Suite**](https://download.sysinternals.com/files/SysinternalsSuite.zip) (23.2 MB)  
 [**Download Sysinternals Suite for Nano Server**](https://download.sysinternals.com/files/SysinternalsSuite-Nano.zip) (4.6 MB)
 
@@ -39,8 +39,3 @@ Utilities:
 [SDelete](sdelete.md), [ShareEnum](shareenum.md), [ShellRunas](shellrunas.md), [Sigcheck](sigcheck.md), [Streams](streams.md), 
 [Strings](strings.md), [Sync](sync.md), [Sysmon](sysmon.md), [TCPView](tcpview.md), [VMMap](vmmap.md), 
 [VolumeID](volumeid.md), [WhoIs](whois.md), [WinObj](winobj.md), [ZoomIt](zoomit.md)
-
-
-[**Download Sysinternals Suite**](https://download.sysinternals.com/files/SysinternalsSuite.zip) (22.6 MB)  
-[**Download Sysinternals Suite for Nano Server**](https://download.sysinternals.com/files/SysinternalsSuite-Nano.zip) (4.7 MB)  
-


### PR DESCRIPTION
The download links for the Sysinternals Suite appear twice in this short
page. The ones at the end of the page seem to not be maintained (in
terms of updating the file sizes), so it seems most people see and use
the top set of links.
In light of the above, and in order to improve overall maintainability,
removing the set of links at the bottom of the page.