### PR TITLE
Changed title from Autologon for WIndows v3.10

### DIFF
--- a/sysinternals/downloads/autologon.md
+++ b/sysinternals/downloads/autologon.md
@@ -7,7 +7,7 @@ ms:mtpsurl: 'https://technet.microsoft.com/en-us/Bb963905(v=MSDN.10)'
 ms.date: 08/29/2016
 ---
 
-Autologon for Windows v3.10
+Autologon v3.10
 ===========================
 
 **By Mark Russinovich**


### PR DESCRIPTION
Changed title because of the Windows 3.1 implication and for consistency with other tools