### PR TITLE
Minor fixes in example

### DIFF
--- a/sysinternals/downloads/psinfo.md
+++ b/sysinternals/downloads/psinfo.md
@@ -62,49 +62,50 @@ for SP 1, etc).
 
 ## Example Output
 
-```Shell
-c:&gt; psinfo \\\\development -h -d  
+```
+C:\> psinfo \\development -h -d
 
-PsInfo v1.6 - local and remote system information viewer  
-Copyright (C) 2001-2004 Mark Russinovich  
-Sysinternals - www.sysinternals.com  
+PsInfo v1.6 - local and remote system information viewer
+Copyright (C) 2001-2004 Mark Russinovich
+Sysinternals - www.sysinternals.com
 
-    System information for \\\\DEVELOPMENT:  
-    Uptime: 28 days, 0 hours, 15 minutes, 12 seconds  
-    Kernel version: Microsoft Windows XP, Multiprocessor Free  
-    Product type Professional  
-    Product version: 5.1  
-    Service pack: 0  
-    Kernel build number: 2600  
-    Registered organization: Sysinternals  
-    Registered owner: Mark Russinovich  
-    Install date: 1/2/2002, 5:29:21 PM  
-    Activation status: Activated  
-    IE version: 6.0000  
-    System root: C:\\WINDOWS  
-    Processors: 2  
-    Processor speed: 1.0 GHz  
-    Processor type: Intel Pentium III  
-    Physical memory: 1024 MB  
-    Volume Type Format Label Size Free Free  
-    A: Removable 0%  
-    C: Fixed NTFS WINXP 7.8 GB 1.3 GB 16%  
-    D: Fixed NTFS DEV 10.7 GB 809.7 MB 7%  
-    E: Fixed NTFS SRC 4.5 GB 1.8 GB 41%  
-    F: Fixed NTFS MSDN 2.4 GB 587.5 MB 24%  
-    G: Fixed NTFS GAMES 8.0 GB 1.0 GB 13%  
-    H: CD-ROM CDFS JEDIOUTCAST 633.6 MB 0%  
-    I: CD-ROM 0% Q: Remote 0%  
-    T: Fixed NTFS Test 502.0 MB 496.7 MB 99%  
-    OS Hot Fix Installed  
-    Q147222 1/2/2002  
-    Q309521 1/4/2002  
-    Q311889 1/4/2002  
-    Q313484 1/4/2002  
-    Q314147 3/6/2002  
-    Q314862 3/13/2002  
-    Q315000 1/8/2002  
-    Q315403 3/13/2002  
+    System information for \\DEVELOPMENT:
+    Uptime: 28 days, 0 hours, 15 minutes, 12 seconds
+    Kernel version: Microsoft Windows XP, Multiprocessor Free
+    Product type Professional
+    Product version: 5.1
+    Service pack: 0
+    Kernel build number: 2600
+    Registered organization: Sysinternals
+    Registered owner: Mark Russinovich
+    Install date: 1/2/2002, 5:29:21 PM
+    Activation status: Activated
+    IE version: 6.0000
+    System root: C:\WINDOWS
+    Processors: 2
+    Processor speed: 1.0 GHz
+    Processor type: Intel Pentium III
+    Physical memory: 1024 MB
+    Volume Type Format Label Size Free Free
+    A: Removable 0%
+    C: Fixed NTFS WINXP 7.8 GB 1.3 GB 16%
+    D: Fixed NTFS DEV 10.7 GB 809.7 MB 7%
+    E: Fixed NTFS SRC 4.5 GB 1.8 GB 41%
+    F: Fixed NTFS MSDN 2.4 GB 587.5 MB 24%
+    G: Fixed NTFS GAMES 8.0 GB 1.0 GB 13%
+    H: CD-ROM CDFS JEDIOUTCAST 633.6 MB 0%
+    I: CD-ROM 0%
+    Q: Remote 0%
+    T: Fixed NTFS Test 502.0 MB 496.7 MB 99%
+    OS Hot Fix Installed
+    Q147222 1/2/2002
+    Q309521 1/4/2002
+    Q311889 1/4/2002
+    Q313484 1/4/2002
+    Q314147 3/6/2002
+    Q314862 3/13/2002
+    Q315000 1/8/2002
+    Q315403 3/13/2002
     Q317277 3/20/2002
 ```
 


### PR DESCRIPTION
No left-slash and HTML escaping needed in pre-formatted sections;
Drop shell metadata as the output had unexpected highlighted words like "for" and "type";
Fix prompt before sample command;
Restore missing line-break;
Trim trailing space.