### PR TITLE
Document the -accepteula flag

### DIFF
--- a/sysinternals/downloads/sigcheck.md
+++ b/sysinternals/downloads/sigcheck.md
@@ -37,9 +37,10 @@ catalog file\] &lt;file or directory&gt;**
 **usage: sigcheck -t\[u\]\[v\] \[-i\] \[-c|-ct\] &lt;certificate store
 name|\*&gt;**
 
-|Parameter  |Description  |
+|Parameter&nbsp;&nbsp;&nbsp;  |Description  |
 |---------|---------|
 |  **-a**      |       Show extended version information. The entropy measure reported is the bits per byte of information of the file's contents.|
+|  **-accepteula**  |  Silently accept the Sigcheck EULA (no interactive prompt)
 |  **-c**      |       CSV output with comma delimiter|
 |  **-ct**     |       CSV output with tab delimiter|
 |  **-d**      |       Dump contents of a catalog file|


### PR DESCRIPTION
This flag was not documented on the page, even though the interactive prompt (which appears only for the first time using the tool) encourages the user to use it.

![image](https://user-images.githubusercontent.com/732314/66945792-f3825b80-f04f-11e9-94c0-14cd301564fb.png)
