### PR TITLE
CPUStress Updates

### DIFF
--- a/sysinternals/downloads/cpustres.md
+++ b/sysinternals/downloads/cpustres.md
@@ -40,7 +40,6 @@ Each thread can be started, paused or stopped independently and can be configure
 
 -   [**Windows Internals Book**](~/learn/windows-internals.md)  The official updates and errata page for the definitive book on
     Windows internals, by Mark Russinovich and David Solomon.
--   [**Pavel's Blog**](https://blogs.microsoft.co.il/pavely/2016/06/11/enhanced-cpu-stress-tool/) Pavel Yosifovich's blog describing the tool
 
 ## Download
 

--- a/sysinternals/downloads/cpustres.md
+++ b/sysinternals/downloads/cpustres.md
@@ -1,6 +1,6 @@
 --- 
 TOCTitle: CpuStres
-title: Testlimit
+title: CpuStres
 description: Windows CPU Stress utility.
 ms:assetid: 'cfbb8960-ca2c-48c3-a05e-ecb1970d3648'
 ms.date: 03/22/2019

--- a/sysinternals/downloads/cpustres.md
+++ b/sysinternals/downloads/cpustres.md
@@ -1,5 +1,5 @@
 --- 
-TOCTitle: Cpustres
+TOCTitle: CpuStres
 title: Testlimit
 description: Windows CPU Stress utility.
 ms:assetid: 'cfbb8960-ca2c-48c3-a05e-ecb1970d3648'
@@ -18,8 +18,8 @@ Published: July 18, 2018
 
 ## Introduction
 
-**Cpustres**  
-Cpustres is a utility that can be used to simulate CPU activity by running 
+**CpuStres**  
+CpuStres is a utility that can be used to simulate CPU activity by running 
 up to 64 threads in a tight loop.
 
 Each thread can be started, paused or stopped independently and can be configured with the following parameters:


### PR DESCRIPTION
There appears to be multiple ways that CPU Stress is noted through the product and this article.  Although the product name is CPU Stress, it seemed to be most referred to be "CpuStress" through this doc, so I ensured they were all capitalized that way (except in links).

Changed title from old "TestLimit" to "CpuStres" to match TOCTitle and product name.

Removed broken link to Pavel's blog - I tried to find its new home first but was unable to.