### PR TITLE
Using common set of hyphen characters in examples

### DIFF
--- a/sysinternals/downloads/sysmon.md
+++ b/sysinternals/downloads/sysmon.md
@@ -114,25 +114,25 @@ Neither install nor uninstall requires a reboot.
 
 Install with default settings (process images hashed with sha1 and no
 network monitoring)  
-**sysmon -accepteula  –i**
+**sysmon -accepteula  -i**
 
 Install Sysmon with a configuration file (as described below)
 
-**sysmon –accepteula –i c:\\windows\\config.xml**
+**sysmon -accepteula -i c:\\windows\\config.xml**
 
 Uninstall  
-**sysmon –u**
+**sysmon -u**
 
 Dump the current configuration  
-**sysmon –c**
+**sysmon -c**
 
 Change the configuration of sysmon with a configuration file (as
 described below)
 
-**sysmon –c c:\\windows\\config.xml**
+**sysmon -c c:\\windows\\config.xml**
 
 Change the configuration to default settings  
-**sysmon –c --**
+**sysmon -c --**
 
 Show the configuration schema:  
 **sysmon -s**


### PR DESCRIPTION
Mixed hyphen are used in the documentation. 
The change is replacing the "LATIN SMALL LETTER A WITH CIRCUMFLEX" character (0xE2) used in the examples with the "HYPHEN-MINUS" character (0x2D).
In some cases copy and past will lead to error in the console.
