### PR TITLE
Adds sysmon64.exe uninstall command

### DIFF
--- a/sysinternals/downloads/sysmon.md
+++ b/sysinternals/downloads/sysmon.md
@@ -86,7 +86,7 @@ Uninstall:               sysmon64 -u [force]
 |  **-c** |  Update configuration of an installed Sysmon driver or dump the current configuration if no other argument is provided. Optionally take a configuration file.|
 |  **-m** |  Install the event manifest (done on service install as well).|
 |  **-s** |  Print configuration schema definition.|
-|  **-u** |  Uninstall service and driver. Adding force causes uninstall to proceed even when some components are not installed.|
+|  **-u** |  Uninstall service and driver. Adding force causes uninstall to proceed even when some components are not installed. It may be necessary to use **sysmon64.exe** in the same directory as the sysmon64.exe file as the command if **sysmon64** does not work|
 
 The service logs events immediately and the driver installs as a
 boot-start driver to capture activity from early in the boot that the


### PR DESCRIPTION
The existing `sysmon -u` and `sysmon -u force` uninstall directions throw a `the service sysmon64 is already registered` error message on some systems, such as this [Lenovo laptop](https://github.com/jdrch/Hardware/blob/master/Lenovo%20L380%20Yoga%20ThinkPad%2020M7CTO1WW.md) (full config details at link.) 

For those cases, the sysmon executable has to be explicitly referenced in an uninstall command run in an elevated PowerShell prompt in the directory containing the executable, e.g. `sysmon64.exe -u` or  `sysmon64.exe -u force`.