### PR TITLE
downloads/procmon.md: Remove "{width=10%}"

### DIFF
--- a/sysinternals/downloads/procmon.md
+++ b/sysinternals/downloads/procmon.md
@@ -63,7 +63,7 @@ options on a live system.
 
 ![Process Monitor screenshot](media/procmon/procmon-main.png)  
 
-![Event Properties screenshot](media/procmon/procmon-proc.png){width=10%}  
+![Event Properties screenshot](media/procmon/procmon-proc.png)  
 
 ## Related Links
 


### PR DESCRIPTION
Hi. In the [download page](https://docs.microsoft.com/en-us/sysinternals/downloads/procmon) of Process Monitor, I found a line of text "{width=10%}" next to a screenshot .

```
 ------------
|            |
|            |
|            |
| screenshot |
|            |
|            |
|            |
 ------------ {width=10%}
```

This line was added in 44cfbbbf10e76371a7da0097d3239c9aa59d00c5 ([git-blame](https://github.com/MicrosoftDocs/sysinternals/blame/44cfbbbf10e76371a7da0097d3239c9aa59d00c5/sysinternals/downloads/procmon.md#L66)). There are no comments about it, so I guess it might be a wrong input, and removed it.

If adding this line is on purpose, please close this PR.
