### PR TITLE
Redirect pendmoves and regjump dl links

### DIFF
--- a/sysinternals/downloads/index.md
+++ b/sysinternals/downloads/index.md
@@ -180,7 +180,7 @@ See the order in which devices are loaded on your WinNT/2K system.
 List the active logon sessions on a system.
 
 [MoveFile](pendmoves.md)  
-*v1.01 (January 24, 2013)*  
+*v1.02 (September 17, 2020)*  
 Allows you to schedule move and delete commands for the next reboot.
 
 [NotMyFault](notmyfault.md)  
@@ -195,7 +195,7 @@ the size and location of the Master File Table (MFT) and MFT-zone, as
 well as the sizes of the NTFS meta-data files.
 
 [PendMoves](pendmoves.md)  
-*v1.2 (February 5, 2013)*  
+*v1.3 (September 17, 2020)*  
 Enumerate the list of file rename and delete commands that will be
 executed the next boot.
 

--- a/sysinternals/downloads/pendmoves.md
+++ b/sysinternals/downloads/pendmoves.md
@@ -7,12 +7,12 @@ ms:mtpsurl: 'https://technet.microsoft.com/Bb897556(v=MSDN.10)'
 ms.date: 09/17/2020
 ---
 
-# PendMoves v1.02 and MoveFile v1.01
+# PendMoves v1.3 and MoveFile v1.02
 
 **By Mark Russinovich**
-Published: July 4, 2016
+Published: September 17, 2020
 
-[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/PendMoves.zip) [**Download PendMovesand MoveFile**](https://download.sysinternals.com/files/PendMoves.zip) **(988 KB)**
+[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/pendmoves.zip) [**Download PendMoves and MoveFile**](https://download.sysinternals.com/files/pendmoves.zip) **(988 KB)**
 
 ## Introduction
 
@@ -45,4 +45,4 @@ Specifying an empty destination  ("") deletes the source at boot. An example tha
 movefile test.exe ""
 ```
 
-[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/PendMoves.zip) [**Download PendMovesand MoveFile**](https://download.sysinternals.com/files/PendMoves.zip) **(988 KB)**
+[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/pendmoves.zip) [**Download PendMoves and MoveFile**](https://download.sysinternals.com/files/pendmoves.zip) **(988 KB)**

--- a/sysinternals/downloads/regjump.md
+++ b/sysinternals/downloads/regjump.md
@@ -13,7 +13,7 @@ ms.date: 10/12/2021
 
 Published: October 12, 2021
 
-[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/RegJump.zip) [**Download RegJump**](https://download.sysinternals.com/files/RegJump.zip) **(164 KB)**
+[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/regjump.zip) [**Download RegJump**](https://download.sysinternals.com/files/regjump.zip) **(164 KB)**
 
 ## Introduction
 
@@ -29,4 +29,4 @@ HKEY\_LOCAL\_MACHINE) and abbreviated form (e.g. HKLM).
 
 e.g.: regjump HKLM\\Software\\Microsoft\\Windows
 
-[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/RegJump.zip) [**Download RegJump**](https://download.sysinternals.com/files/RegJump.zip) **(164 KB)**
+[![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/regjump.zip) [**Download RegJump**](https://download.sysinternals.com/files/regjump.zip) **(164 KB)**


### PR DESCRIPTION
This is temporary, as the PascalCasing links are the correct ones.