### PR TITLE
Update doc to be consistent with command help

### DIFF
--- a/sysinternals/downloads/du.md
+++ b/sysinternals/downloads/du.md
@@ -29,7 +29,7 @@ directory and its subdirectories.
 |Parameter  |Description  |
 |---------|---------|
 |  **-c** |  Print output as CSV. Use -ct for tab delimiting.|
-|  **-l** |  Specify subdirectory depth of information (default is one level).|
+|  **-l** |  Specify subdirectory depth of information (default is 0 levels).|
 |  **-n** |  Do not recurse.|
 |  **-v** |  Show size (in KB) of intermediate directories.|
 |  **-u** |  Count each instance of a hardlinked file.|

--- a/sysinternals/downloads/du.md
+++ b/sysinternals/downloads/du.md
@@ -29,15 +29,16 @@ directory and its subdirectories.
 |Parameter  |Description  |
 |---------|---------|
 |  **-c** |  Print output as CSV. Use -ct for tab delimiting.|
-|  **-l** |  Specify subdirectory depth of information (default is all levels).|
+|  **-l** |  Specify subdirectory depth of information (default is one level).|
 |  **-n** |  Do not recurse.|
 |  **-v** |  Show size (in KB) of intermediate directories.|
 |  **-u** |  Count each instance of a hardlinked file.|
-|  **-q** |  Quiet (no banner).|
+|  **-q** |  Quiet.|
+|  **-nobanner** |  Do not display the startup banner and copyright message.|
 
 CSV output is formatted as:
 
 Path, CurrentFileCount, CurrentFileSize, FileCount, DirectoryCount,
-DirectorySize
+DirectorySize, DirectorySizeOnDisk
 
 [![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/DU.zip) [**Download Du**](https://download.sysinternals.com/files/DU.zip) **(1.62 MB)**


### PR DESCRIPTION
The online documentation does not include the `-nobanner` option, and does not show **DirectorySizeOnDisk** is part of the CSV output.

Output of `du.exe /?` for v1.62:
```
DU v1.62 - Directory disk usage reporter
Copyright (C) 2005-2018 Mark Russinovich
Sysinternals - www.sysinternals.com

usage: c:\sysinternals\du.exe [-c[t]] [-l <levels> | -n | -v] [-u] [-q] <directory>
   -c     Print output as CSV. Use -ct for tab delimiting.
          Use -nobanner to suppress banner.
   -l     Specify subdirectory depth of information (default is one level).
   -n     Do not recurse.
   -q     Quiet.
   -nobanner
          Do not display the startup banner and copyright message.
   -u     Count each instance of a hardlinked file.
   -v     Show size (in KB) of all subdirectories.

CSV output is formatted as:
Path,CurrentFileCount,CurrentFileSize,FileCount,DirectoryCount,DirectorySize,DirectorySizeOnDisk
```