### PR TITLE
update junction.md

### DIFF
--- a/sysinternals/downloads/junction.md
+++ b/sysinternals/downloads/junction.md
@@ -69,7 +69,6 @@ junction -s c:\
 To create a junction c:\\Program-Files for "c:\\Program Files":
 
 ```cmd
-md Program-Files
 junction c:\Program-Files "c:\Program Files"
 ```
 


### PR DESCRIPTION
I removed line 72   <md Program-Files> as you cannot have and existing folder for <junction target>.  "Error creating c:\Program-Files:
Cannot create a file when that file already exists." is the resulting error.  Once that step is removed (no <junction target>) the rest of the steps work fine! Tested in Windows 11 Pro.