### PR TITLE
Sysinternals Live - Usage Wording - Path

### DIFF
--- a/sysinternals/index.md
+++ b/sysinternals/index.md
@@ -21,7 +21,11 @@ The Sysinternals web site was created in 1996 by [Mark Russinovich](https://blog
 ---
 ## Sysinternals Live
 
-Sysinternals Live is a service that enables you to execute Sysinternals tools directly from the Web without hunting for and manually downloading them. Simply enter a tool's Sysinternals Live path into Windows Explorer or a command prompt as live.sysinternals.com/&lt;toolname&gt; or  \\\\live.sysinternals.com\tools\\&lt;toolname&gt;.
+Sysinternals Live is a service that enables you to execute Sysinternals tools directly from the Web without hunting for and manually downloading them.
+
+Simply enter a tool's Sysinternals Live path into **Windows Explorer** as **live.sysinternals.com/&lt;toolname&gt;** or **\\\\live.sysinternals.com\tools\\&lt;toolname&gt;**.
+
+Alternatively, you can utilise **command prompt** instead with the format of **\\\\live.sysinternals.com\tools\\&lt;toolname&gt;**.
 
 You can view the entire Sysinternals Live tools directory in a browser at [https://live.sysinternals.com/](https://live.sysinternals.com).
 

--- a/sysinternals/index.md
+++ b/sysinternals/index.md
@@ -23,8 +23,8 @@ The Sysinternals web site was created in 1996 by [Mark Russinovich](https://blog
 
 Sysinternals Live is a service that enables you to run Sysinternals tools directly from the Web without manually downloading them.
 
-Enter a tool's Sysinternals Live path into **Windows Explorer** as `live.sysinternals.com/<toolname>` or `\\live.sysinternals.com\tools\<toolname>`.
-The format for **command prompt** or **PowerShell** is `\\live.sysinternals.com\tools\<toolname>`.
+Enter a tool's Sysinternals Live path in Windows Explorer as `live.sysinternals.com/<toolname>` or `\\live.sysinternals.com\tools\<toolname>`.
+In a command prompt use `\\live.sysinternals.com\tools\<toolname>`.
 
 You can view the entire Sysinternals Live tools directory in a browser or Windows Explorer at [https://live.sysinternals.com/](https://live.sysinternals.com).
 

--- a/sysinternals/index.md
+++ b/sysinternals/index.md
@@ -21,13 +21,12 @@ The Sysinternals web site was created in 1996 by [Mark Russinovich](https://blog
 ---
 ## Sysinternals Live
 
-Sysinternals Live is a service that enables you to execute Sysinternals tools directly from the Web without hunting for and manually downloading them.
+Sysinternals Live is a service that enables you to run Sysinternals tools directly from the Web without manually downloading them.
 
-Simply enter a tool's Sysinternals Live path into **Windows Explorer** as **live.sysinternals.com/&lt;toolname&gt;** or **\\\\live.sysinternals.com\tools\\&lt;toolname&gt;**.
+Enter a tool's Sysinternals Live path into **Windows Explorer** as `live.sysinternals.com/<toolname>` or `\\live.sysinternals.com\tools\<toolname>`.
+The format for **command prompt** or **PowerShell** is `\\live.sysinternals.com\tools\<toolname>`.
 
-Alternatively, you can utilise **command prompt** instead with the format of **\\\\live.sysinternals.com\tools\\&lt;toolname&gt;**.
-
-You can view the entire Sysinternals Live tools directory in a browser at [https://live.sysinternals.com/](https://live.sysinternals.com).
+You can view the entire Sysinternals Live tools directory in a browser or Windows Explorer at [https://live.sysinternals.com/](https://live.sysinternals.com).
 
 ## What's New [![RSS icon](media/index/rss.gif)](https://techcommunity.microsoft.com/plugins/custom/microsoft/o365/custom-blog-rss?board=Sysinternals-Blog)
 


### PR DESCRIPTION
Checked that the live.sysinternals.com/<toolname> method does not work with the command prompt when provided as is - only the the \\live.sysinterrnals.com\tools\<toolname> format works with the command prompt.

Previous wording implied that the command prompt will work with both.

Also added emphasis for readability.