### PR TITLE
Fixed issue with opening on Windows Store

### DIFF
--- a/sysinternals/downloads/sysinternals-suite.md
+++ b/sysinternals/downloads/sysinternals-suite.md
@@ -16,7 +16,7 @@ Updated: July 23, 2024
 [**Download Sysinternals Suite**](https://download.sysinternals.com/files/SysinternalsSuite.zip) (50.4 MB)  
 [**Download Sysinternals Suite for Nano Server**](https://download.sysinternals.com/files/SysinternalsSuite-Nano.zip) (9.5 MB)  
 [**Download Sysinternals Suite for ARM64**](https://download.sysinternals.com/files/SysinternalsSuite-ARM64.zip) (15 MB)  
-[**Install Sysinternals Suite from the Microsoft Store**](https://www.microsoft.com/store/apps/9p7knl5rwt25)  
+[**Install Sysinternals Suite from the Microsoft Store**](ms-windows-store://pdp/?ProductId=9p7knl5rwt25)
 
 ## Introduction
 


### PR DESCRIPTION
## What is this PR about

This PR fixes the way a user is directed to the Microsoft Store to download the Sysinternals Suite.

Currently, the ["Install Sysinternals Suite from the Microsoft Store"](https://www.microsoft.com/store/apps/9p7knl5rwt25) link is misbehaving. 
The current behaviour of the link is as follows:

1. Sometimes, the link yeilds a 503

![image](https://github.com/user-attachments/assets/70896fe5-ef93-4883-84ad-0ced4bb14aa1)

2. Sometimes, the link yields a missing page

![image](https://github.com/user-attachments/assets/13de2a70-6dfb-4514-bd6e-172773c197a2)

3. Sometimes, it takes unreasonable amount of time to get redirected to `apps.microsoft` which techinically is a Microsoft Store but on the web as opposed to the user's local Microsoft Store which is more intuitive for user to install from.

![image](https://github.com/user-attachments/assets/253028a8-79d8-4e47-a162-c26abe2e476c)

## Solution
According to [UWP documentation](https://learn.microsoft.com/en-us/windows/uwp/launch-resume/launch-store-app), the recommended way to link to a specific product/software in the Windows Store / Microsoft Store is by using `ms-windows-store://pdp/?ProductId=XXXXXXX` and this PR does that. 

## Alternative Solution
Refer to [apps.microsoft.com](https://apps.microsoft.com/detail/9p7knl5rwt25) page for Sysinternals Suite directly. 

