### PR TITLE
[BULK] - DocuTune remediation - Red Tiger deprecation 

### DIFF
--- a/sysinternals/downloads/autoruns.md
+++ b/sysinternals/downloads/autoruns.md
@@ -17,7 +17,7 @@ Published: February 6, 2024
 [![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/Autoruns.zip) [**Download Autoruns and Autorunsc**](https://download.sysinternals.com/files/Autoruns.zip) **(2.8 MB)**  
 **Run now** from [Sysinternals Live](https://live.sysinternals.com/autoruns.exe).
 <br><br>
-> [!VIDEO https://www.microsoft.com/en-us/videoplayer/embed/RW14GhU?autoplay=true&loop=true&controls=false]
+> [!VIDEO https://learn-video.azurefd.net/vod/player?id=ff2f39c9-26d2-49d6-b060-2c00a62679a9]
 <sup><i>Created with [ZoomIt](zoomit.md)</i></sup>
 
 ## Introduction

--- a/sysinternals/downloads/process-explorer.md
+++ b/sysinternals/downloads/process-explorer.md
@@ -17,7 +17,7 @@ Published: May 28, 2024
 [![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/ProcessExplorer.zip) [**Download Process Explorer**](https://download.sysinternals.com/files/ProcessExplorer.zip) **(3.3 MB)**  
 **Run now** from [Sysinternals Live](https://live.sysinternals.com/procexp.exe).
 <br><br>
-> [!VIDEO https://www.microsoft.com/en-us/videoplayer/embed/RE5d5Rd?autoplay=true&loop=true&controls=false]
+> [!VIDEO https://learn-video.azurefd.net/vod/player?id=27421f3d-e796-4ecd-935d-ea78cd638757]
 <sup><i>Created with [ZoomIt](zoomit.md)</i></sup>
 
 ## Introduction

--- a/sysinternals/downloads/zoomit.md
+++ b/sysinternals/downloads/zoomit.md
@@ -17,7 +17,7 @@ Published: December 16, 2024
 [![Download](media/shared/Download_sm.png)](https://download.sysinternals.com/files/ZoomIt.zip) [**Download ZoomIt**](https://download.sysinternals.com/files/ZoomIt.zip) **(1.4 MB)**
 **Run now** from [Sysinternals Live](https://live.sysinternals.com/ZoomIt.exe).
 <br><br>
-> [!VIDEO https://www.microsoft.com/en-us/videoplayer/embed/RE55yQm?autoplay=true&loop=true&controls=false]
+> [!VIDEO https://learn-video.azurefd.net/vod/player?id=31330ae9-ccc2-4001-a9ce-35dcbb8b5aa2]
 <sup>*Created with ZoomIt*</sup>
 
 ## Introduction


### PR DESCRIPTION
Replacing deprecated Red Tiger video embeds with migrated Learn Videos. Point of contact: @meganbradley

DocuTune v1.5.2.0
CorrelationId: [ac50b370-fbb9-4fcc-b22d-306bf6bf2281](https://github.com/MicrosoftDocs/sysinternals/pulls?q=is%3Apr+ac50b370-fbb9-4fcc-b22d-306bf6bf2281+)

#docutune
